### PR TITLE
[Platform] CI configuration update

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: 🔨 Select Xcode
-      run: xcodes select 16.2
+      run: xcodes select 26.2
     - name: Checkout Code
       uses: actions/checkout@v4
     - name: 🛠️ Build
@@ -24,11 +24,11 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: 🔨 Select Xcode
-      run: xcodes select 16.2
+      run: xcodes select 26.2
     - name: Checkout Code
       uses: actions/checkout@v4
     - name: 🧪 Run tests
-      run: xcodebuild test -scheme "pingx" -testPlan "pingx" -destination "OS=18.2,name=iPhone 16 Pro"
+      run: xcodebuild test -scheme "pingx" -testPlan "pingx" -destination "OS=26.2,name=iPhone 17"
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4.0.1
       with:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Checkout Code
       uses: actions/checkout@v4
     - name: 🧪 Run tests
-      run: xcodebuild test -scheme "pingx" -testPlan "pingx" -destination "OS=26.2,name=iPhone 17"
+      run: xcodebuild test -scheme "pingx" -testPlan "pingx" -destination "OS=26.1,name=iPhone 17"
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4.0.1
       with:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: 🔨 Select Xcode
-      run: xcodes select 26.2
+      run: xcodes select 26.1.1
     - name: Checkout Code
       uses: actions/checkout@v4
     - name: 🛠️ Build
@@ -24,7 +24,7 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: 🔨 Select Xcode
-      run: xcodes select 26.2
+      run: xcodes select 26.1.1
     - name: Checkout Code
       uses: actions/checkout@v4
     - name: 🧪 Run tests

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # pingx
 
 [![CI](https://github.com/shineRR/pingx/actions/workflows/swift.yml/badge.svg)](https://github.com/shineRR/pingx/actions/workflows/swift.yml)
-[![Version](https://img.shields.io/cocoapods/v/pingx.svg?style=flat)](https://cocoapods.org/pods/pingx)
+[![Platform](https://img.shields.io/cocoapods/p/pingx.svg?style=flat)](https://cocoapods.org/pods/pingx)
 [![License](https://img.shields.io/cocoapods/l/pingx.svg?style=flat)](https://cocoapods.org/pods/pingx)
+[![Version](https://img.shields.io/cocoapods/v/pingx.svg?style=flat)](https://cocoapods.org/pods/pingx)
 [![codecov](https://codecov.io/gh/shineRR/pingx/graph/badge.svg?token=OJSHN8KMHJ)](https://codecov.io/gh/shineRR/pingx)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/98fb2f3d80c64d7d88ee725e3038a6db)](https://app.codacy.com/gh/shineRR/pingx/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
-[![Platform](https://img.shields.io/cocoapods/p/pingx.svg?style=flat)](https://cocoapods.org/pods/pingx)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Version](https://img.shields.io/cocoapods/v/pingx.svg?style=flat)](https://cocoapods.org/pods/pingx)
 [![License](https://img.shields.io/cocoapods/l/pingx.svg?style=flat)](https://cocoapods.org/pods/pingx)
 [![codecov](https://codecov.io/gh/shineRR/pingx/graph/badge.svg?token=OJSHN8KMHJ)](https://codecov.io/gh/shineRR/pingx)
-[![codebeat badge](https://codebeat.co/badges/c7617707-3b8c-4c41-9094-aa152757df55)](https://codebeat.co/projects/github-com-shinerr-pingx-main)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/98fb2f3d80c64d7d88ee725e3038a6db)](https://app.codacy.com/gh/shineRR/pingx/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 [![Platform](https://img.shields.io/cocoapods/p/pingx.svg?style=flat)](https://cocoapods.org/pods/pingx)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # pingx
 
+[![CI](https://github.com/shineRR/pingx/actions/workflows/swift.yml/badge.svg)](https://github.com/shineRR/pingx/actions/workflows/swift.yml)
 [![Version](https://img.shields.io/cocoapods/v/pingx.svg?style=flat)](https://cocoapods.org/pods/pingx)
 [![License](https://img.shields.io/cocoapods/l/pingx.svg?style=flat)](https://cocoapods.org/pods/pingx)
 [![codecov](https://codecov.io/gh/shineRR/pingx/graph/badge.svg?token=OJSHN8KMHJ)](https://codecov.io/gh/shineRR/pingx)


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the GitHub Actions configuration for the `swift.yml` workflow and modifies the `README.md` file to improve the CI badge and add a platform badge.

### Detailed summary
- Updated `Xcode` selection from `16.2` to `26.1.1`.
- Changed test destination from `OS=18.2,name=iPhone 16 Pro` to `OS=26.1,name=iPhone 17`.
- Replaced the CI badge in `README.md` with a link to the current GitHub Actions workflow.
- Added a platform badge in `README.md`.
- Retained the existing version and license badges in `README.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->